### PR TITLE
Potential fix for code scanning alert no. 26: disallow unused variables

### DIFF
--- a/client/js/client/nad-client.js
+++ b/client/js/client/nad-client.js
@@ -162,25 +162,25 @@ bassUnsetButton.addEventListener('click', () => nad.unsetBass());
 
 bassToggle.addEventListener('change', () => {
     if (bassToggle.checked) {
-        nad.setBass().then(r => {}).catch(console.error);
+        nad.setBass().then(() => {}).catch(console.error);
     } else {
-        nad.unsetBass().then(r => {}).catch(console.error);
+        nad.unsetBass().then(() => {}).catch(console.error);
     }
 });
 
 autoSenseToggle.addEventListener('change', () => {
     if (autoSenseToggle.checked) {
-        nad.setAutoSense().then(r => {}).catch(console.error);
+        nad.setAutoSense().then(() => {}).catch(console.error);
     } else {
-        nad.unsetAutoSense().then(r => {}).catch(console.error);
+        nad.unsetAutoSense().then(() => {}).catch(console.error);
     }
 });
 
 autoStandbyToggle.addEventListener('change', () => {
     if (autoStandbyToggle.checked) {
-        nad.setAutoStandby().then(r => {}).catch(console.error);
+        nad.setAutoStandby().then(() => {}).catch(console.error);
     } else {
-        nad.unsetAutoStandby().then(r => {}).catch(console.error);
+        nad.unsetAutoStandby().then(() => {}).catch(console.error);
     }
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/ado24/NAD-C338-Controller/security/code-scanning/26](https://github.com/ado24/NAD-C338-Controller/security/code-scanning/26)

To fix the problem, we should remove the unused variable `r` from the `.then()` callback. Since the callback does not use the resolved value of the promise, we can omit the parameter entirely. This will eliminate the ESLint error while preserving the existing functionality of the code.

The changes will be made to the `.then()` callbacks on lines 165, 167, 173, 175, 181, and 183, as they all define `r` but do not use it.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
